### PR TITLE
🐛 방 내부 곡 duration 수정 

### DIFF
--- a/mavve/src/components/RoomInsidePage/NowPlaying.jsx
+++ b/mavve/src/components/RoomInsidePage/NowPlaying.jsx
@@ -3,6 +3,14 @@ import * as S from '../../pages/RoomInsidePage/RoomInsidePage.style';
 import Stop from '../../assets/RoomInsidePage/roomin_icn_play.svg';
 
 function NowPlaying({ currentSong }) {
+  // duration 밀리초를 분:초로 변환 
+  const formatDuration = (ms) => {
+    const totalSeconds = Math.floor(ms / 1000);
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+
+    return `${minutes}:${seconds.toString().padStart(2, '0')}`; // 한자리 숫자를 두자리로 만들어줌 
+  };
     return (
       <S.NowPlayingContainer>
         <S.ShadowWrapper>
@@ -14,7 +22,7 @@ function NowPlaying({ currentSong }) {
           <S.NowTitle>{currentSong?.title || "재생 중인 곡 없음"}</S.NowTitle>
           <S.NowArtist>{currentSong?.artist || "-"}</S.NowArtist>
           <S.NowDuration>
-            {currentSong?.duration ? `${currentSong.duration}` : ""}
+            {formatDuration(currentSong?.duration ? `${currentSong.duration}` : "")}
           </S.NowDuration>
         </S.NowPlayingBar>
       </S.NowPlayingContainer>

--- a/mavve/src/components/RoomInsidePage/RoomPlayList.jsx
+++ b/mavve/src/components/RoomInsidePage/RoomPlayList.jsx
@@ -175,6 +175,15 @@ function RoomPlayList({ isChatOpen, setIsChatOpen, songEvent, roomCode, currentS
     });
   }, [currentSong]);
 
+  // duration 밀리초를 분:초로 변환 
+  const formatDuration = (ms) => {
+    const totalSeconds = Math.floor(ms / 1000);
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+
+    return `${minutes}:${seconds.toString().padStart(2, '0')}`; // 한자리 숫자를 두자리로 만들어줌 
+  };
+
 
   return (
     <>
@@ -246,7 +255,7 @@ function RoomPlayList({ isChatOpen, setIsChatOpen, songEvent, roomCode, currentS
                 <div>{song.artist}</div>
               </S.SongTextInfo>
               <S.SongAlbum $isChatOpen={isChatOpen}>{song.album}</S.SongAlbum>
-              <S.SongDuration>{song.duration}</S.SongDuration>
+              <S.SongDuration>{formatDuration(song.duration)}</S.SongDuration>
             </S.SongRow>
           );
         })


### PR DESCRIPTION
## ✅ 작업 내용
백엔드에서 넘겨주는 song duration 데이터가 ms로 되어 있어서 분:초의 형태로 표시되게 수정하였습니당. 

---

## 📌 관련 이슈
- 관련 이슈: #43 

---

## 💬 특이사항


---

## 🖼️ 스크린샷 (선택)
<img width="1440" height="683" alt="스크린샷 2025-07-31 오전 12 54 15" src="https://github.com/user-attachments/assets/de838c3c-7ba6-417d-9ae4-b919de134df6" />


