### PR TITLE
🐛 방 생성 후 UI 깨짐 수정

### DIFF
--- a/mavve/src/components/RoomPage/RoomInfoHeader.jsx
+++ b/mavve/src/components/RoomPage/RoomInfoHeader.jsx
@@ -46,7 +46,11 @@ function RoomInfoHeader({ roomInfo, setRoomInfo, selectedLists, step, setThumbna
       <S.HeaderTextArea>
         <S.VisibilityText>{roomInfo.visibility}</S.VisibilityText>
         <S.TitleArea>
-          <S.RoomTitle>{roomInfo.title || "방 제목"}</S.RoomTitle>
+          <S.RoomTitle>{roomInfo.title
+                          ? roomInfo.title.length > 8
+                            ? `${roomInfo.title.slice(0, 8)}...`
+                            : roomInfo.title
+                          : "방 제목"}</S.RoomTitle>
           {totalPlaylists > 0 && step === "done" &&
               <S.SubInfo>
                <div>플레이리스트 {totalPlaylists}개</div>

--- a/mavve/src/pages/RoomPage/RoomPage.jsx
+++ b/mavve/src/pages/RoomPage/RoomPage.jsx
@@ -16,7 +16,7 @@ export default function RoomPage() {
     hashtags: [],
     visibility: "전체공개",
   });
-
+ 
   const [selectedLists, setSelectedLists] = useState([]);
 
   const [step, setStep] = useState("search"); 

--- a/mavve/src/pages/RoomPage/RoomPage.style.js
+++ b/mavve/src/pages/RoomPage/RoomPage.style.js
@@ -387,7 +387,7 @@ export const EmptyThumbnail = styled.div`
 export const HeaderTextArea = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 21px;
+  gap: 20px;
 `;
 
 export const VisibilityText = styled.div`
@@ -400,6 +400,7 @@ export const VisibilityText = styled.div`
 `;
 
 export const TitleArea = styled.div`
+  width: 45rem;
   display: flex;
   align-items: center;
   gap: 2rem;
@@ -464,10 +465,6 @@ export const SubInfo = styled.div`
 
 `;
 
-export const DeleteBtnWrapper = styled.div`
-  display: flex;
-  
-`;
 
 export const RoomDeleteBtn = styled.button`
   display: inline-flex;
@@ -485,7 +482,6 @@ export const RoomDeleteBtn = styled.button`
   font-style: normal;
   font-weight: 500;
   line-height: 1.5rem; 
-  position: sticky;
   margin-top: 9.9rem;
 
   &:active {
@@ -514,7 +510,7 @@ export const RoomEnterBtn = styled.button`
   font-weight: 500;
   line-height: 1.5rem; 
   margin-top: 9.9rem;
-  margin-left: 20rem;
+  margin-left: 10rem; 
   &:active {
     transform: scale(0.925); 
   }


### PR DESCRIPTION
## ✅ 작업 내용
방 생성 후 화면에서 방 제목이 너무 길면 두 줄이 되면서 UI가 깨져서, 제목이 8자가 넘으면 뒷부분은 ...로 표시되도록 수정하였습니다. 

---

## 📌 관련 이슈
- 관련 이슈: #46 

---

## 💬 특이사항

---

## 🖼️ 스크린샷 (선택)
<img width="1440" height="683" alt="KakaoTalk_Photo_2025-07-31-17-41-29" src="https://github.com/user-attachments/assets/1a10a25e-8c6e-4609-b9aa-8075e6335804" />


