### PR TITLE
🐛 방 내부 곡 startTime 반영

### DIFF
--- a/mavve/src/pages/RoomInsidePage/RoomInsidePage.jsx
+++ b/mavve/src/pages/RoomInsidePage/RoomInsidePage.jsx
@@ -79,11 +79,34 @@ function RoomInsidePage(){
      useEffect(() => {
        if (roomData?.currentSong?.song) {
          setCurrentSong(roomData.currentSong.song);
-         setStartTime(roomData.currentSong.startTime); 
        }
      }, [roomData]);
-    
      
+     // 곡 시점 계산하기 (seekPosition)
+     useEffect(() => {
+        const raw = roomData?.currentSong?.startTime;
+        if (!roomData?.currentSong?.song || !raw) return;
+      
+        const sanitized = raw.split('.')[0] + 'Z';
+        const parsed = new Date(sanitized);
+        const now = new Date();
+      
+        const elapsedMs = now - parsed;
+        const seekPosition = Math.floor(elapsedMs / 1000);
+      
+        const song = roomData.currentSong.song;
+        setCurrentSong({
+          ...song,
+          seekPosition
+        });
+      
+        console.log("seekPosition (초):", seekPosition);
+      }, [roomData]);
+      
+    
+    
+    
+    
     return(
         <S.RoomInsidePageContainer>
             <TopBar />


### PR DESCRIPTION
## ✅ 작업 내용
- 방에 입장할 때 기존에 곡의 어느 시점을 재생하고 있었는지도 계산해야 할 것 같아 api 응답으로 받는 currentSong의 startTime을 이용하여 seekPosition (곡 재생 시작할 위치)도 정의를 해놓았습니다. 

---

## 📌 관련 이슈
- 관련 이슈: #58 

---

## 💬 특이사항
- SDK 연결 시 사용 예정!! 
---

## 🖼️ 스크린샷 (선택)


