### PR TITLE
Fix/#67

### DIFF
--- a/mavve/src/api/diary.js
+++ b/mavve/src/api/diary.js
@@ -17,8 +17,15 @@ export const createDiary = async ({ emojiId, spotifySongId, comment }) => {
 
 //한 줄 일기 개별 조회하기 (마이페이지)
 export const fetchDiaryByUser = async () => {
-  const response = await axiosInstance.get("/diaries/user");
-  return response.data;
+  try {
+    const response = await axiosInstance.get("/diaries/user");
+    return response.data;
+  } catch (error) {
+    if (error.response?.status === 404) {
+      return null;
+    }
+    throw error;
+  }
 };
 
 //한 줄 일기 수정하기(마이페이지)

--- a/mavve/src/components/Common/Menu.jsx
+++ b/mavve/src/components/Common/Menu.jsx
@@ -51,7 +51,7 @@ export default function Menu({
       console.error("❌ 로그아웃 실패:", err);
     } finally {
       localStorage.removeItem("accessToken");
-      setUser(null);
+      setUser({ nickname: "", profile: "" });
       alert("로그아웃이 완료되었습니다!");
       navigate("/");
     }

--- a/mavve/src/components/Common/RoomSearch.style.js
+++ b/mavve/src/components/Common/RoomSearch.style.js
@@ -88,6 +88,7 @@ export const ResultItem = styled.div`
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
+  cursor: pointer;
 
   &:hover {
     border-radius: 0.5rem;

--- a/mavve/src/components/Common/TopBar.jsx
+++ b/mavve/src/components/Common/TopBar.jsx
@@ -28,7 +28,10 @@ export default function TopBar() {
         const data = await fetchUserInfo();
         setUser(data);
       } catch (err) {
-        console.error("TopBar에서 사용자 정보 가져오기 실패:", err);
+        console.error(
+          "TopBar에서 사용자 정보 가져오기 실패(로그인 되지 않은 사용자 혹은 오류):",
+          err
+        );
       }
     };
 

--- a/mavve/src/pages/LoginPage/LoginLoadPage.jsx
+++ b/mavve/src/pages/LoginPage/LoginLoadPage.jsx
@@ -10,7 +10,6 @@ export default function LoginLoad() {
 
   useEffect(() => {
     const code = new URLSearchParams(window.location.search).get("code");
-    console.log("✅ 받은 code:", code);
 
     if (!code) {
       setMessage("❌ URL에 인증 코드가 없습니다.");

--- a/mavve/src/pages/MyPage/MyPage.jsx
+++ b/mavve/src/pages/MyPage/MyPage.jsx
@@ -21,7 +21,6 @@ import { fetchDiaryByUser, deleteDiary } from "../../api/diary";
 export default function MyPage() {
   const { user, setUser, updateProfile } = useUserStore();
   const navigate = useNavigate();
-  //const [user, setUser] = useState({ nickname: "", profile: "" });
   const [myRooms, setMyRooms] = useState([]);
   const [likedRooms, setLikedRooms] = useState([]);
   const [noteData, setNoteData] = useState({});
@@ -60,6 +59,10 @@ export default function MyPage() {
     const fetchDiary = async () => {
       try {
         const data = await fetchDiaryByUser();
+        if (!data) {
+          setNoteData({});
+          return;
+        }
 
         console.log("📒 불러온 일기 데이터:", data);
 
@@ -81,7 +84,6 @@ export default function MyPage() {
         console.error("한 줄 일기 조회 실패:", error);
       }
     };
-
     fetchDiary();
   }, []);
 


### PR DESCRIPTION
## ✅ 작업 내용
- 한 줄 일기가 작성되지 않았을 때 "한 줄 일기 조회 실패" 에러가 뜨지 않도록 수정
- 로그아웃 이후 로그인 화면으로 이동하도록 수정
- 방 관련 경로 수정

---

## 📌 관련 이슈
- 관련 이슈: #67 

---

## 💬 특이사항
- 로그아웃 이후에 사용자 정보가 없어서 에러가 나는 걸 수정 중이었는데, 만약 초기 화면과 로그아웃 이후 이동 페이지를 로그인 화면으로 설정하면 사용자 정보 없이 렌더링 되는 경우는 없을거라서 우선 그대로 두었습니다.
- 한 줄 일기 작성 전에 API를 요청하면 404에러가 발생하는데, 이건 브라우저에서 보내는거라 제가 막을 수 없는 것 같습니다!ㅜ

---

## 🖼️ 스크린샷 (선택)

