### PR TITLE
🐛 컨텍스트 메뉴 클릭 버그 수정

### DIFF
--- a/mavve/src/components/Common/RoomComponent.jsx
+++ b/mavve/src/components/Common/RoomComponent.jsx
@@ -8,7 +8,7 @@ import EditIcon from "../../assets/Common/icn_edit.svg";
 import DeleteIcon from "../../assets/Common/icn_delete.svg";
 
 export default function RoomComponent({
-  data,  
+  data,
   isMyRoom,
   contextMenuTargetId,
   setContextMenuTargetId,
@@ -114,7 +114,7 @@ export default function RoomComponent({
           }}
         >
           <S.EditMenu
-            onClick={(e) => {
+            onMouseDown={(e) => {
               e.stopPropagation();
               handleEdit();
             }}
@@ -127,7 +127,7 @@ export default function RoomComponent({
             세부 정보 수정하기
           </S.EditMenu>
           <S.DeleteMenu
-            onClick={(e) => {
+            onMouseDown={(e) => {
               e.stopPropagation();
               handleDelete();
             }}


### PR DESCRIPTION
## ✅ 작업 내용
- 컨텍스트 메뉴의 옵션 버튼을 누르면 모달 창이 뜨지 않고 방 클릭으로 인식 되는 현상 수정함
- 컨텍스트 메뉴 버튼 클릭을 Click -> MouseDown으로 변경

---

## 📌 관련 이슈
- 관련 이슈: #109 

---

## 💬 특이사항
- mouseDown이 onClick 보다 먼저 실행됨. 버그가 발생한 이유는 방 컴포넌트 스타일에 &:active 옵션을 추가하면서 컨텍스트 메뉴 창 클릭까지 방 클릭으로 인식되는 문제였음


